### PR TITLE
fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ packadd scope.vim
 The appearance of the popup window can be customized using `borderchars`,
 `borderhighlight`, `highlight`, `scrollbarhighlight`, `thumbhighlight`, and
 other `:h popup_create-arguments`. To configure these settings, use
-`g:ScopePopupOptionsSet()`.
+`scope#popup#OptionsSet()`.
 
 For example, to set the border of the popup window to the `Comment` highlight group:
 
 ```vim
-g:ScopePopupOptionsSet({borderhighlight: ['Comment']})
+scope#popup#OptionsSet({borderhighlight: ['Comment']})
 ```
 
 The `ScopeMenuMatch` highlight group modifies the appearance of characters

--- a/autoload/scope/popup.vim
+++ b/autoload/scope/popup.vim
@@ -11,6 +11,10 @@ export var options = {
     # cursorchar: '█',
 }
 
+export def OptionsSet(opt: dict<any>)
+    options->extend(opt)
+enddef
+
 export class FilterMenu
 
     var prompt: string = ''

--- a/doc/scope.txt
+++ b/doc/scope.txt
@@ -171,11 +171,11 @@ Add the following line to your $HOME/.vimrc file.
 
 Popup window appearance can be configured. `borderchars`, `borderhighlight`,
 `highlight`, `scrollbarhighlight`, `thumbhighlight` and  other `:h popup_create-arguments` 
-can be configured using `g:ScopePopupOptionsSet()`.
+can be configured using `scope#popup#OptionsSet()`.
 
 To set border of popup window to `Comment` highlight group:
 >
-	g:ScopePopupOptionsSet({borderhighlight: ['Comment']})
+	scope#popup#OptionsSet({borderhighlight: ['Comment']})
 <
 `ScopeMenuMatch` highlight group modifies the look of characters searched so
 far. It is linked to `Special` by default.

--- a/plugin/scope.vim
+++ b/plugin/scope.vim
@@ -5,9 +5,3 @@ endif
 vim9script
 
 g:loaded_scope = true
-
-import autoload '../autoload/scope/popup.vim'
-
-def! g:ScopePopupOptionsSet(opt: dict<any>)
-    popup.options->extend(opt)
-enddef


### PR DESCRIPTION
There could be some bug with the 'import' mechanism in vim9script.

If `g:ScopePopupOptionsSet` is called in the vimrc, the file will be correctly imported in autoload/scope/fuzzy.vim as well. If the function isn't called, fuzzy.vim won't be able to import popup.vim. I think because the import is tagged as 'autoload' the first time, and fuzzy.vim assumes (wrongly) that the script has been sourced already.

For now, move the setup function in the popup script, so that it is'nt imported. Moreover, using a function defined in the plugin/ script forces to use `packadd` instead of `packadd!`, otherwise the global function isn't available in the vimrc.