### PR TITLE
Fix grep cmd options

### DIFF
--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -132,7 +132,7 @@ export def File(findCmd: string = null_string, count: number = 10000)  # list at
 enddef
 
 def GrepCmd(): string
-    return 'grep --color=never -RESIHin --exclude="*.git*" --exclude="*.swp" --exclude="*.zwc" --exclude-dir=plugged'
+    return 'grep --color=never -REIHin --exclude="*.git*" --exclude="*.swp" --exclude="*.zwc" --exclude-dir=plugged'
 enddef
 
 var prev_grep = null_string


### PR DESCRIPTION
Seems to me `-S` is not a valid cli option in grep (at least on linux?)
Uncommenting the `echoerr` from line 34 in `task.vim` helped me spot the issue. Maybe it should stay that way or is there any reason for ignoring errors ?