### PR TITLE
Make grepcmd compatible with ripgrep

### DIFF
--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -164,7 +164,7 @@ export def Grep(grepcmd: string = '', ignorecase: bool = true)
             echo ''
         endif
         if prompt != null_string
-            var cmd = (grepcmd ?? GrepCmd()) .. ' ' .. prompt
+            var cmd = (grepcmd ?? GrepCmd()) .. ' ' .. prompt .. ' ./'
             cmd = cmd->escape('*')
             if options.grep_echo_cmd
                 echo cmd


### PR DESCRIPTION
Appending `' ./'` after the prompt makes it work with both grep and ripgrep.
For example like this:
```
fuzzy.Grep('rg --vimgrep --glob=!.git --smart-case')
```