### PR TITLE
Mininum prompt length before launching grep command

### DIFF
--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -82,7 +82,7 @@ export def Grep(grepCmd: string = null_string, ignorecase: bool = true)
         if options.grep_echo_cmd
             echo ''
         endif
-        if prompt != null_string
+        if (prompt != null_string) && (prompt->len() > 3)
             var cmd = $'{grepCmd ?? util.GrepCmd()} {prompt}'
             if grepCmd->match('^\S*rg\s\|^\S*rg$') != -1
                 # 'rg' needs a './' at the end


### PR DESCRIPTION
If you do a live grep on a sizable code-base (eg. vim source code), instantly launching grep after first char is typed will make the search hang for a bit of time. In my experience, I doubt one would want to grep a code-base with less than 4 chars. With 4 chars, the results from ripgrep are almost instant. 

Of course there could be other ways to go about it, like delaying the first grep by 200ms or so to give time to user to type more than 1 char, for example. But I feel this has the benefit of being super simple and to work well in practice.

Feel free to close if you think there's better ways to handle this.

Edit: could make the value configurable so user can adjust to their liking (eventually with a default value of 0 to keep the current behaviour, even though I think 3 is a sane default :smiley:). Just let me know where to set this config option.