### PR TITLE
add command for each function

### DIFF
--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -74,7 +74,7 @@ var prev_grep = null_string
 # of parsing color codes, Vim's syntax highlighting is used. As Vim lacks
 # awareness of `grep`'s ignore-case flag, explicit instruction is needed for
 # accurate highlighting.
-export def Grep(grepCmd: string = null_string, ignorecase: bool = true, cword: string = null_string)
+export def Grep(cword: string = null_string, grepCmd: string = null_string, ignorecase: bool = true)
     var menu: popup.FilterMenu
     var timer_delay = max([1, options.timer_delay])
     var grep_poll_interval = max([10, options.grep_poll_interval])

--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -74,7 +74,7 @@ var prev_grep = null_string
 # of parsing color codes, Vim's syntax highlighting is used. As Vim lacks
 # awareness of `grep`'s ignore-case flag, explicit instruction is needed for
 # accurate highlighting.
-export def Grep(cword: string = null_string, grepCmd: string = null_string, ignorecase: bool = true)
+export def Grep(grepCmd: string = null_string, ignorecase: bool = true, cword: string = null_string)
     var menu: popup.FilterMenu
     var timer_delay = max([1, options.timer_delay])
     var grep_poll_interval = max([10, options.grep_poll_interval])
@@ -189,6 +189,11 @@ export def Grep(cword: string = null_string, grepCmd: string = null_string, igno
                 echo ''
             endif
         }, true)
+enddef
+
+#wrapper function for Grep() for fast search by keyword in command line
+export def GrepFast(cword: string = null_string)
+    Grep(null_string, true, cword)
 enddef
 
 export def Buffer(list_all_buffers: bool = false)

--- a/plugin/scope.vim
+++ b/plugin/scope.vim
@@ -12,27 +12,27 @@ g:loaded_scope = true
 # not contain column pattern, add it.
 set grepformat^=%f:%l:%c:%m
 
-command!          FzfAutocmd           call fuzzy.Autocmd()	                    #Vim autocommands, go to their declaration on <cr>
-command!          FzfBufSearch         call fuzzy.BufSearch()	                #Words in current buffer
-command!          FzfBuffer            call fuzzy.Buffer()	                    #Open buffers (option to search 'unlisted' buffers)
-command!          FzfCmdHistory        call fuzzy.CmdHistory()	                #Command history
-command!          FzfColorscheme       call fuzzy.Colorscheme()	                #Available color schemes
-command!          FzfCommand           call fuzzy.Command()	                    #Vim commands
-command!          FzfFile              call fuzzy.File()	                    #Files in current working directory
-command!          FzfFiletype          call fuzzy.Filetype()	                #File types
-command!          FzfGitFile           call fuzzy.GitFile()	                    #Files under git
-command! -nargs=* FzfGrep              call fuzzy.Grep(<f-args>)	            #Live grep in current working directory (spaces allowed)
-command!          FzfHelp              call fuzzy.Help()	                    #Help topics
-command!          FzfHighlight         call fuzzy.Highlight()	                #Highlight groups
-command!          FzfKeymap            call fuzzy.Keymap()	                    #Key mappings, go to their declaration on <cr>
-command!          FzfLoclist           call fuzzy.Loclist()	                    #Items in the location list (sets 'current entry')
-command!          FzfLoclistHistory    call fuzzy.LoclistHistory()	            #Entries in the location list stack
-command!          FzfMRU               call fuzzy.MRU()	                        #:h v:oldfiles
-command!          FzfMark              call fuzzy.Mark()	                    #Vim marks (:h mark-motions)
-command!          FzfOption            call fuzzy.Option()	                    #Vim options and their values
-command!          FzfQuickfix          call fuzzy.Quickfix()	                #Items in the quickfix list (sets 'current entry')
-command!          FzfQuickfixHistory   call fuzzy.QuickfixHistory()	            #Entries in the quickfix list stack
-command!          FzfRegister          call fuzzy.Register()	                #Vim registers, paste contents on <cr>
-command!          FzfTag               call fuzzy.Tag()	                        #:h ctags search
-command!          FzfWindow            call fuzzy.Window()	                    #Open windows
+command!          ScopeAutocmd           call fuzzy.Autocmd()
+command!          ScopeBufSearch         call fuzzy.BufSearch()
+command!          ScopeBuffer            call fuzzy.Buffer()
+command!          ScopeCmdHistory        call fuzzy.CmdHistory()
+command!          ScopeColorscheme       call fuzzy.Colorscheme()
+command!          ScopeCommand           call fuzzy.Command()
+command!          ScopeFile              call fuzzy.File()
+command!          ScopeFiletype          call fuzzy.Filetype()
+command!          ScopeGitFile           call fuzzy.GitFile()
+command! -nargs=* ScopeGrep              call fuzzy.GrepFast(<f-args>)
+command!          ScopeHelp              call fuzzy.Help()
+command!          ScopeHighlight         call fuzzy.Highlight()
+command!          ScopeKeymap            call fuzzy.Keymap()
+command!          ScopeLoclist           call fuzzy.Loclist()
+command!          ScopeLoclistHistory    call fuzzy.LoclistHistory()
+command!          ScopeMRU               call fuzzy.MRU()
+command!          ScopeMark              call fuzzy.Mark()
+command!          ScopeOption            call fuzzy.Option()
+command!          ScopeQuickfix          call fuzzy.Quickfix()
+command!          ScopeQuickfixHistory   call fuzzy.QuickfixHistory()
+command!          ScopeRegister          call fuzzy.Register()
+command!          ScopeTag               call fuzzy.Tag()
+command!          ScopeWindow            call fuzzy.Window()
 

--- a/plugin/scope.vim
+++ b/plugin/scope.vim
@@ -4,8 +4,35 @@ if !has('vim9script') ||  v:version < 901
 endif
 vim9script
 
+import autoload 'scope/fuzzy.vim'
+
 g:loaded_scope = true
 
 # ripgrep output can include column number. default values of grepformat does
 # not contain column pattern, add it.
 set grepformat^=%f:%l:%c:%m
+
+command!          FzfAutocmd           call fuzzy.Autocmd()	                    #Vim autocommands, go to their declaration on <cr>
+command!          FzfBufSearch         call fuzzy.BufSearch()	                #Words in current buffer
+command!          FzfBuffer            call fuzzy.Buffer()	                    #Open buffers (option to search 'unlisted' buffers)
+command!          FzfCmdHistory        call fuzzy.CmdHistory()	                #Command history
+command!          FzfColorscheme       call fuzzy.Colorscheme()	                #Available color schemes
+command!          FzfCommand           call fuzzy.Command()	                    #Vim commands
+command!          FzfFile              call fuzzy.File()	                    #Files in current working directory
+command!          FzfFiletype          call fuzzy.Filetype()	                #File types
+command!          FzfGitFile           call fuzzy.GitFile()	                    #Files under git
+command! -nargs=* FzfGrep              call fuzzy.Grep(<f-args>)	            #Live grep in current working directory (spaces allowed)
+command!          FzfHelp              call fuzzy.Help()	                    #Help topics
+command!          FzfHighlight         call fuzzy.Highlight()	                #Highlight groups
+command!          FzfKeymap            call fuzzy.Keymap()	                    #Key mappings, go to their declaration on <cr>
+command!          FzfLoclist           call fuzzy.Loclist()	                    #Items in the location list (sets 'current entry')
+command!          FzfLoclistHistory    call fuzzy.LoclistHistory()	            #Entries in the location list stack
+command!          FzfMRU               call fuzzy.MRU()	                        #:h v:oldfiles
+command!          FzfMark              call fuzzy.Mark()	                    #Vim marks (:h mark-motions)
+command!          FzfOption            call fuzzy.Option()	                    #Vim options and their values
+command!          FzfQuickfix          call fuzzy.Quickfix()	                #Items in the quickfix list (sets 'current entry')
+command!          FzfQuickfixHistory   call fuzzy.QuickfixHistory()	            #Entries in the quickfix list stack
+command!          FzfRegister          call fuzzy.Register()	                #Vim registers, paste contents on <cr>
+command!          FzfTag               call fuzzy.Tag()	                        #:h ctags search
+command!          FzfWindow            call fuzzy.Window()	                    #Open windows
+


### PR DESCRIPTION
Hello,  I try to write vim9 plugins only vim config and I really like your plugin.
This pull request make small changes that have the following purpose:
1. allows not to use import in .vimrc
2. allows to use command line commands for not frequency used function and not to use key bind for it or if need  use function with parameters. As example you can use :FzfGrep Foo if keyword "Foo" not exist in your buffer 