### PR TITLE
add a function to create a MenuFilter with autoload

### DIFF
--- a/autoload/scope/popup.vim
+++ b/autoload/scope/popup.vim
@@ -403,3 +403,7 @@ export class FilterMenu
         matchaddpos('ScopeMenuCursor', [[1, bytepos]], 10, -1, {window: this.idp})
     enddef
 endclass
+
+export def NewFilterMenu(title: string, items_dict: list<dict<any>>, Callback: func(any, string), Setup: func(number, number) = null_function, GetFilteredItems: func(list<any>, string): list<any> = null_function, Cleanup: func() = null_function, maximize: bool = false): FilterMenu
+    return FilterMenu.new(title, items_dict, Callback, Setup, GetFilteredItems, Cleanup, maximize)
+enddef


### PR DESCRIPTION
This function allows creating a MenuFilter without using an import to use the class, eg if somebody needs to create some code using the popup in a function and doesn't want to import the popup file in a whole script.