### PR TITLE
Optional parameter to make Buffer() always use current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,20 @@ import autoload 'scope/fuzzy.vim'
 nnoremap <your_key> <scriptcmd>fuzzy.Buffer(true)<cr>
 ```
 
+Hide unlisted buffers and always use current window
+
+```vim
+vim9script
+import autoload 'scope/fuzzy.vim'
+nnoremap <your_key> <scriptcmd>fuzzy.Buffer(v:none, false)<cr>
+```
+
 ### API
 
 ```vim
 # list_all_buffers: Boolean : If 'true', include unlisted buffers as well.
-def Buffer(list_all_buffers: bool = false)
+# goto_window: Boolean : If 'false', do not go to other window.
+def Buffer(list_all_buffers: bool = false, goto_window: bool = true )
 ```
 
 ## Search Current Buffer

--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -271,7 +271,7 @@ export def Grep(grepCmd: string = null_string, ignorecase: bool = true,
         }, true)
 enddef
 
-export def Buffer(list_all_buffers: bool = false)
+export def Buffer(list_all_buffers: bool = false, goto_window: bool = true)
     var blist = list_all_buffers ? getbufinfo({buloaded: 1}) : getbufinfo({buflisted: 1})
     var buffer_list = blist->mapnew((_, v) => {
         return {bufnr: v.bufnr,
@@ -290,7 +290,7 @@ export def Buffer(list_all_buffers: bool = false)
                     (v: dict<any>) => {
                         return {bufnr: v.bufnr, text: v.text}
                     })
-                if res.winid != -1
+                if res.winid != -1 && goto_window
                     win_gotoid(res.winid)
                 else
                     util.VisitBuffer(key, res.bufnr)

--- a/doc/scope.txt
+++ b/doc/scope.txt
@@ -200,10 +200,17 @@ Search unlisted buffers as well.
 	import autoload 'scope/fuzzy.vim'
 	nnoremap <your_key> <scriptcmd>fuzzy.Buffer(true)<cr>
 <
+Hide unlisted buffers and always use current window
+>
+	vim9script
+	import autoload 'scope/fuzzy.vim'
+	nnoremap <your_key> <scriptcmd>fuzzy.Buffer(v:none, false)<cr>
+<
 API ~
 >
 	# list_all_buffers: Boolean : If 'true', include unlisted buffers as well.
-	def Buffer(list_all_buffers: bool = false)
+	# goto_window: Boolean : If 'false', do not go to other window.
+	def Buffer(list_all_buffers: bool = false, goto_window: bool = true )
 
 Search Current Buffer ~
 


### PR DESCRIPTION
Add and optional boolean parameter to Buffer function to control going to other windows.

Default value is true to maintain current behavior

This allows to always reuse current window when switching buffers, similar to default :buffer command
(I personally use Window() to jump to an already "visible" buffer 😉 )

If you prefer, this also could be done with an option variable like in https://github.com/girishji/scope.vim/commit/f4bb40bb781b6878bc7f426a1a2ed085eba02c28 instead of changing the function API