### PR TITLE
fix cyclic import

### DIFF
--- a/autoload/scope/util.vim
+++ b/autoload/scope/util.vim
@@ -1,7 +1,5 @@
 vim9script
 
-import './fuzzy.vim'
-
 export def VisitFile(key: string, filename: string, lnum: number = -1)
     var cmd = {"\<C-j>": 'split', "\<C-v>": 'vert split', "\<C-t>": 'tabe'}
     if lnum > 0
@@ -199,7 +197,7 @@ export def Send2Qickfix(key: string, unfiltered: list<dict<any>>, filtered: list
     var lst = ["\<C-q>", "\<C-l>"]->index(key) != -1 ? filtered : unfiltered
     var qflist = ["\<C-q>", "\<C-Q>"]->index(key) != -1
     var SetXList = qflist ? function('setqflist') : function('setloclist', [0])
-    var qf_stack = fuzzy.options.quickfix_stack
+    var qf_stack = fuzzy#options.quickfix_stack
     var action = qf_stack ? ' ' : 'r'
     var what: dict<any> = qf_stack ? {nr: '$', title: title} : {title: title}
     if !lst->empty()


### PR DESCRIPTION
After patch 9.1.1014, cyclic import in autoload no longer works.

`help :import-cycle`(https://github.com/vim/vim/commit/57f0119358ed7f060d5020309b9043463121435f#diff-276d2fe6d42680e6055997d47473f23e9e2811387be6377ccc488071bb9d324fR2054):
```vimhelp
							*:import-cycle* *E1045*
The `import` commands are executed when encountered.  It can be nested up to
'maxfuncdepth' levels deep.  If script A imports script B, and B (directly or
indirectly) imports A, this will be skipped over.  At this point items in A
after "import B" will not have been processed and defined yet.  Therefore
cyclic imports can exist and not result in an error directly, but may result
in an error for items in A after "import B" not being defined.  This does not
apply to autoload imports, see the next section.
```