### PR TITLE
Fix E1167 error: Shadow variable

### DIFF
--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -16,8 +16,8 @@ export var options: dict<any> = {
     mru_rel_path: false,
 }
 
-export def OptionsSet(opt: dict<any>)
-    options->extend(opt)
+export def OptionsSet(option: dict<any>)
+    options->extend(option)
 enddef
 
 export def FindCmd(dir: string = '.'): string

--- a/autoload/scope/popup.vim
+++ b/autoload/scope/popup.vim
@@ -212,7 +212,7 @@ export class FilterMenu
                             this.cursorpos = 3
                             this._CursorSet()
                         endif
-                    elseif key == "\<End>" || key == "\<C-e>" 
+                    elseif key == "\<End>" || key == "\<C-e>"
                         if this.cursorpos < (3 + this.prompt->strcharlen())
                             this.cursorpos = 3 + this.prompt->strcharlen()
                             this._CursorSet()


### PR DESCRIPTION
There is another error after fixing cyclic import.

Probably because in lsp plugin there is this line in file ...\autoload\lsp.vim:
```import './options.vim' as opt```