### PR TITLE
fix: resolve Vim9 type mismatch in File picker selection

### DIFF
--- a/autoload/scope/fuzzy.vim
+++ b/autoload/scope/fuzzy.vim
@@ -33,11 +33,13 @@ export def File(findCmd: string = null_string, count: number = 100000, ignore_er
     var menu: popup.FilterMenu
     menu = popup.FilterMenu.new("File", [],
         (res, key) => {
-            if !util.Send2Qickfix(key, menu.items_dict, menu.filtered_items[0], cmd,
+            var selected_list: list<dict<any>> = [res]
+
+            if !util.Send2Qickfix(key, menu.items_dict, selected_list, cmd,
                     (v: dict<any>) => {
                         return {filename: v.text}
                     }) &&
-                    !util.Send2Buflist(key, menu.filtered_items[0]->mapnew('v:val.text'))
+                    !util.Send2Buflist(key, [res.text])
                 util.VisitFile(key, res.text)
             endif
             if options.find_echo_cmd


### PR DESCRIPTION
Hi, this fix resolves a Vim9 type mismatch when selecting a file in the File picker after filtering.

<img width="1920" height="1200" alt="20260504-101217_1xMay" src="https://github.com/user-attachments/assets/57e70872-fc17-4db2-a7c1-e91f2a421a9c" />


